### PR TITLE
Enable TLS auth by default

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -83,6 +83,7 @@ openvpn_as_vpn_server_routing_private_networks: []
 openvpn_as_vpn_server_routing_routed_subnets: []
 openvpn_as_vpn_server_static_netmask_bits: 24
 openvpn_as_vpn_server_static_network: ''
+openvpn_as_vpn_server_tls_auth: true
 openvpn_as_vpn_server_tls_version_min: default
 
 openvpn_as_vpn_tls_refresh_interval: 360

--- a/templates/config.json.j2
+++ b/templates/config.json.j2
@@ -193,6 +193,11 @@
     "vpn.server.static.0.netmask_bits": "{{ openvpn_as_vpn_server_static_netmask_bits }}",
     "vpn.server.static.0.network": "{{ openvpn_as_vpn_server_static_network }}",
 {% endif %}
+{% if openvpn_as_vpn_server_tls_auth %}
+    "vpn.server.tls_auth": "true",
+{% else %}
+    "vpn.server.tls_auth": "false",
+{% endif %}
     "vpn.server.tls_version_min": "{{ openvpn_as_vpn_server_tls_version_min }}",
     "vpn.tls_refresh.do_reauth": "true",
     "vpn.tls_refresh.interval": "{{ openvpn_as_vpn_tls_refresh_interval }}",


### PR DESCRIPTION
By default, TLS auth was disabled on the server, but client profiles have a <tls-auth> section, which makes it impossible to connect to VPN server "out of the box".